### PR TITLE
Fix pip package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is generated using Swagger Codegen from our OpenAPI API definition. For docum
 ## Installation
 
 This package can be installed from pip:
-`pip install onshape`
+`pip install onshape-client`
 
 ## Quick example
 


### PR DESCRIPTION
The README says to use `pip install onshape` but the package is `onshape-client`: https://pypi.org/project/onshape-client/